### PR TITLE
Add buttons to add a meal plan to a specific point in time

### DIFF
--- a/cookbook/templates/meal_plan.html
+++ b/cookbook/templates/meal_plan.html
@@ -8,6 +8,25 @@
 {% endblock %}
 
 {% block content %}
+    <style>
+        .mealplan-cell .mealplan-add-button{
+            text-align: center;
+            display: block;
+        }
+
+        @media (hover: hover) {
+            .mealplan-cell .mealplan-add-button{
+                visibility: hidden;
+                float: right;
+                display: inline;
+            }
+
+            .mealplan-cell:hover .mealplan-add-button{
+                visibility: initial;
+            }
+        }
+
+    </style>
 
     <h3>
         {% trans 'Meal-Plan' %} <a href="{% url 'new_meal_plan' %}"><i class="fas fa-plus-circle"></i></a>
@@ -53,8 +72,8 @@
                     </tr>
                     <tr>
                         {% for day_key, days_value in plan_value.days.items %}
-                            <td>
-                                <a href="{% url 'new_meal_plan' %}?date={{ day_key|date:'Y-m-d' }}&meal={{ plan_key }}"><i class="fas fa-plus"></i></a><br/>
+                            <td class="mealplan-cell">
+                                <a class="mealplan-add-button" href="{% url 'new_meal_plan' %}?date={{ day_key|date:'Y-m-d' }}&meal={{ plan_key }}"><i class="fas fa-plus"></i></a>
                                 {% for mp in days_value %}
                                     <a href="{% url 'edit_meal_plan' mp.pk %}"><i class="fas fa-edit"></i></a>
                                     <a href="{% url 'view_recipe' mp.recipe.id %}">{{ mp.recipe.name }}</a><br/>

--- a/cookbook/templates/meal_plan.html
+++ b/cookbook/templates/meal_plan.html
@@ -54,6 +54,7 @@
                     <tr>
                         {% for day_key, days_value in plan_value.days.items %}
                             <td>
+                                <a href="{% url 'new_meal_plan' %}?date={{ day_key|date:'Y-m-d' }}&meal={{ plan_key }}"><i class="fas fa-plus"></i></a><br/>
                                 {% for mp in days_value %}
                                     <a href="{% url 'edit_meal_plan' mp.pk %}"><i class="fas fa-edit"></i></a>
                                     <a href="{% url 'view_recipe' mp.recipe.id %}">{{ mp.recipe.name }}</a><br/>

--- a/cookbook/views/new.py
+++ b/cookbook/views/new.py
@@ -1,4 +1,5 @@
 import re
+from datetime import datetime
 
 from django.contrib import messages
 from django.contrib.auth.decorators import login_required
@@ -119,6 +120,12 @@ class MealPlanCreate(LoginRequiredMixin, CreateView):
     model = MealPlan
     form_class = MealPlanForm
     success_url = reverse_lazy('view_plan')
+
+    def get_initial(self):
+        return dict(
+            meal=self.request.GET['meal'] if 'meal' in self.request.GET else None,
+            date=datetime.strptime(self.request.GET['date'], '%Y-%m-%d') if 'date' in self.request.GET else None
+        )
 
     def form_valid(self, form):
         obj = form.save(commit=False)


### PR DESCRIPTION
Hey, hope you don't mind me barging in :) I've been meaning to replace my own homegrown unfinished recipe manager and stumbled upon yours. I might run this for myself with some modifications and figured you might like some of them. 

This adds some buttons to the meal planner that open the new-meal-plan form with the `date` and `meal` fields prefilled.

![image](https://user-images.githubusercontent.com/2150982/77957036-2608d380-72d3-11ea-9bf8-2e8d1f6c9651.png)

