### PR TITLE
Make links in recipe clickable

### DIFF
--- a/cookbook/templates/recipe_view.html
+++ b/cookbook/templates/recipe_view.html
@@ -194,7 +194,7 @@
 
     <div style="font-size: large">
         {% if recipe.instructions %}
-            {{ recipe.instructions | markdown | safe }}
+            {{ recipe.instructions | markdown | safe | urlize }}
         {% endif %}
     </div>
 


### PR DESCRIPTION
This makes any links that you put into your recipe clickable. I use this when i'm too lazy to fill in the recipe right away and just paste the link as a placeholder.