### PR TITLE
Made recipe images hyperlinked

### DIFF
--- a/cookbook/tables.py
+++ b/cookbook/tables.py
@@ -5,12 +5,22 @@ from django_tables2.utils import A  # alias for Accessor
 
 from .models import *
 
+from django.utils.safestring import mark_safe
+from django.templatetags.static import static
 
-class ImageUrlColumn(tables.Column):
+class ImageUrlColumn(tables.LinkColumn):
     def render(self, value):
         if value.url:
-            return value.url
-        return None
+            src = value.url
+            _class = ''
+            style = 'object-fit: cover;'
+        
+        else:
+            src = static("recipe_no_image.svg")
+            _class = 'd-none d-lg-block'
+            style = 'object-fit: inherit;'
+            
+        return mark_safe(f'<img src="{src}" alt="{_("Recipe Image")}" class="card-img {_class}" style="{style} height:130px">')
 
 
 class RecipeTableSmall(tables.Table):
@@ -30,7 +40,7 @@ class RecipeTable(tables.Table):
     name = tables.LinkColumn('view_recipe', args=[A('id')])
     all_tags = tables.Column(
         attrs={'td': {'class': 'd-none d-lg-table-cell'}, 'th': {'class': 'd-none d-lg-table-cell'}})
-    image = ImageUrlColumn()
+    image = ImageUrlColumn('view_recipe', args=[A('id')])
 
     class Meta:
         model = Recipe

--- a/cookbook/templates/recipes_table.html
+++ b/cookbook/templates/recipes_table.html
@@ -14,16 +14,7 @@
                             <div class="card" style="margin-top: 2px;">
                                 <div class="row no-gutters">
                                     <div class="col-md-4">
-                                        {% if row.cells.image|length > 1 %}
-                                            <img src=" {{ row.cells.image }}" alt="{% trans 'Recipe Image' %}"
-                                                 class="card-img" style="object-fit: cover;height: 130px">
-                                        {% else %}
-                                            <img src="{% static 'recipe_no_image.svg' %}"
-                                                 alt="{% trans 'Recipe Image' %}"
-                                                 class="card-img d-none d-lg-block"
-                                                 style="object-fit: inherit; height: 130px">
-
-                                        {% endif %}
+                                        {{ row.cells.image }}
                                     </div>
                                     <div class="col-md-8">
                                         <div class="card-body">


### PR DESCRIPTION
Attached is a suggested change to make it so you can click on the picture of the recipe (or the blank image supplied) to proceed to the instructions. As of right now, you have to click on the name of the recipe, and the image has no hyperlink. (Note, this only works at all if using the "Search Style: Large" setting.)

I'm honestly not super well-versed on Django so it was a bit of a stumble through. I also broke out the added elements with variables since much of the tags are reused. Obviously those could be simplified into one line (in [cookbook/tables.py](https://github.com/vabene1111/recipes/blob/445c01bddc6bbf3f195d6cec67dcd18e656629ed/cookbook/tables.py#L11)) as so:

```
    def render(self, value):
        if value.url:
            return mark_safe(f'<img src="{value.url}" alt="{_("Recipe Image")}" class="card-img" style="object-fit: cover; height:130px">')
        return mark_safe(f'<img src="{static("recipe_no_image.svg")}" alt="{_("Recipe Image")}" class="card-img d-none d-lg-block" style="object-fit: inherit; height:130px">')
```

Finally, if you were more interested in just having the changes in one file, there is also the option to edit [cookbook/templates/recipes_table.html](https://github.com/vabene1111/recipes/blob/445c01bddc6bbf3f195d6cec67dcd18e656629ed/cookbook/templates/recipes_table.html#L16) as follows:

```
<div class="col-md-4">
    <a href="/view/recipes/{{ row.cells.id }}">
        {% if row.cells.image|length > 1 %}
            <img src=" {{ row.cells.image }}" alt="{% trans 'Recipe Image' %}"
                    class="card-img" style="object-fit: cover;height: 130px">
        {% else %}
            <img src="{% static 'recipe_no_image.svg' %}"
                    alt="{% trans 'Recipe Image' %}"
                    class="card-img d-none d-lg-block"
                    style="object-fit: inherit; height: 130px">

        {% endif %}
    </a>
</div>
```

Both add links, but one has more of a requirement on hard-coding the URL, while the other adds HTML to the Python code, which I didn't know if it was all that desirable...

Thoughts? Github doesn't really give me the option to show all three different possibilities without making different branches for each, but I'd be happy to provide them that way, if you'd like.