### PR TITLE
Adding Reverse Proxy Authentication

### DIFF
--- a/docs/docker/nginx-proxy with proxy authentication/README.md
+++ b/docs/docker/nginx-proxy with proxy authentication/README.md
@@ -1,0 +1,15 @@
+This is a further example combining the power of nginx with the reverse proxy authentication service, [Authelia](https://github.com/authelia/authelia).
+
+Please refer to the appropriate documentation on how to setup the reverse proxy, authentication, and networks.
+
+Ensure users have been configured for Authelia, and that the endpoint that recipes is pointed to is protected, but available.
+
+There is a good guide to the other additional files that need to be added to your Nginx set up at the [Authelia Docs](https://docs.authelia.com/deployment/supported-proxies/nginx.html).
+
+Remember to add the appropriate environment variables to `.env` file:
+```
+VIRTUAL_HOST=
+LETSENCRYPT_HOST=
+LETSENCRYPT_EMAIL=
+PROXY_HEADER=
+```

--- a/docs/docker/nginx-proxy with proxy authentication/docker-compose.yml
+++ b/docs/docker/nginx-proxy with proxy authentication/docker-compose.yml
@@ -1,0 +1,43 @@
+version: "3"
+services:
+  db_recipes:
+    restart: always
+    image: postgres:11-alpine
+    volumes:
+      - ./postgresql:/var/lib/postgresql/data
+    env_file:
+      - ./.env
+    networks:
+      - default
+
+  web_recipes:
+    image: vabene1111/recipes
+    restart: always
+    env_file:
+      - ./.env
+    volumes:
+      - ./staticfiles:/opt/recipes/staticfiles
+      - ./mediafiles:/opt/recipes/mediafiles
+    depends_on:
+      - db_recipes
+    networks:
+      - default
+
+    nginx_recipes:
+      image: nginx:mainline-alpine
+      restart: always
+      env_file:
+        - ./.env
+      volumes:
+        - ./nginx/conf.d:/etc/nginx/conf.d
+        - ./staticfiles:/static
+        - ./mediafiles:/media
+      networks:
+        - default
+        - nginx-proxy
+
+networks:
+  default:
+  nginx-proxy:
+    external:
+      name: nginx-proxy

--- a/docs/docker/nginx-proxy with proxy authentication/nginx/conf.d/Recipes.conf
+++ b/docs/docker/nginx-proxy with proxy authentication/nginx/conf.d/Recipes.conf
@@ -1,0 +1,37 @@
+server {
+  listen 80;
+  server_name localhost;
+
+  client_max_body_size 16M;
+
+  # serve static files
+  location /static/ {
+    alias /static/;
+  }
+  # serve media files
+  location /media/ {
+    alias /media/;
+  }
+  
+  # Authelia endpoint for authentication requests
+  include /config/nginx/auth.conf;
+
+  # pass requests for dynamic content to gunicorn
+  location / {
+    proxy_set_header Host $host;
+    proxy_pass http://web_recipes:8080;
+
+    # Ensure Authelia is specifically required for this endpoint
+    # This line is important as it will return a 401 error if the user doesn't have access
+    include /config/nginx/authelia.conf;
+
+    auth_request_set $user $upstream_http_remote_user;
+    proxy_set_header REMOTE-USER $user;
+  }
+
+  # Required to allow user to logout of authentication from within Recipes
+  # Ensure the <auth_endpoint> below is changed to actual the authentication url
+  location /accounts/logout/ {
+    return 301 http://<auth_endpoint>/logout
+  }
+}

--- a/recipes/middleware.py
+++ b/recipes/middleware.py
@@ -1,0 +1,4 @@
+from django.contrib.auth.middleware import RemoteUserMiddleware
+
+class CustomRemoteUser(RemoteUserMiddleware):
+    header = getenv('PROXY_HEADER', 'HTTP_REMOTE_USER')

--- a/recipes/middleware.py
+++ b/recipes/middleware.py
@@ -1,4 +1,5 @@
 from django.contrib.auth.middleware import RemoteUserMiddleware
+from os import getenv
 
 class CustomRemoteUser(RemoteUserMiddleware):
     header = getenv('PROXY_HEADER', 'HTTP_REMOTE_USER')

--- a/recipes/settings.py
+++ b/recipes/settings.py
@@ -67,6 +67,12 @@ MIDDLEWARE = [
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.locale.LocaleMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
+    'recipes.middleware.CustomRemoteUser',
+    ]
+
+AUTHENTICATION_BACKENDS = [
+    'django.contrib.auth.backends.RemoteUserBackend',
+    'django.contrib.auth.backends.ModelBackend',
 ]
 
 ROOT_URLCONF = 'recipes.urls'


### PR DESCRIPTION
See #81.

This Pull Request will allow you to log in to recipes by looking for a matching request header. If there is no matching header, Django automatically falls back to using the built-in/standard User/Password login functionality of `django.contrib.auth.backends.ModelBackend` (i.e., what is currently used.)

If the user _does not exist in recipes_, but does have access granted via the authentication server, Django silently lets the user access the site, but will not _create_ that user in the database:

![image](https://user-images.githubusercontent.com/520246/83658098-5bf25e80-a587-11ea-81e4-bd0ba76e016c.png)

I tried to add some documentation/deployment details as well, but, given this also requires a functioning authentication server, which could have lots of different implementations, it's rather sparse. I'm happy to expand upon that, though, if needed.

Let me know if there any issues!