### PR TITLE
Fix ingredient parser to allow Plural-suffixes

### DIFF
--- a/cookbook/helper/ingredient_parser.py
+++ b/cookbook/helper/ingredient_parser.py
@@ -58,6 +58,9 @@ def parse_ingredient(tokens):
     ingredient = ''
     note = ''
     if tokens[-1].endswith(')'):
+        # Check if the matching opening bracket is in the same token
+        if ((not tokens[-1].startswith('(')) and ('(' in tokens[-1])):
+            return parse_ingredient_with_comma(tokens)
         # last argument ends with closing bracket -> look for opening bracket
         start = len(tokens) - 1
         while not tokens[start].startswith('(') and not start == 0:

--- a/cookbook/helper/ingredient_parser.py
+++ b/cookbook/helper/ingredient_parser.py
@@ -129,6 +129,9 @@ def parse(x):
                 # only two arguments, first one is the amount which means this is the ingredient
                 ingredient = tokens[1]
         except ValueError:
-            # can't parse first argument as amount -> no unit -> parse everything as ingredient
-            ingredient, note = parse_ingredient(tokens)
+            try:
+                # can't parse first argument as amount -> no unit -> parse everything as ingredient
+                ingredient, note = parse_ingredient(tokens)
+            except ValueError:
+                ingredient = ' '.join(tokens[1:])
     return amount, unit.strip(), ingredient.strip(), note.strip()

--- a/cookbook/tests/other/test_edits_recipe.py
+++ b/cookbook/tests/other/test_edits_recipe.py
@@ -1,6 +1,6 @@
 import json
 
-from cookbook.helper.ingredient_parser import parse_ingredient
+from cookbook.helper.ingredient_parser import parse
 from cookbook.helper.recipe_url_import import get_from_html
 from cookbook.tests.test_setup import TestBase
 
@@ -83,5 +83,5 @@ class TestEditsRecipe(TestBase):
         count = 0
         for key, val in expectations.items():
             count += 1
-            parsed = parse_ingredient(key)
-            self.assertNotEqual(val, parsed)
+            parsed = parse(key)
+            self.assertEqual(val, parsed)

--- a/cookbook/tests/other/test_edits_recipe.py
+++ b/cookbook/tests/other/test_edits_recipe.py
@@ -74,7 +74,8 @@ class TestEditsRecipe(TestBase):
             "ägg": (0, "", "ägg", ""),
             "50 g smör eller margarin": (50, "g", "smör eller margarin", ""),
             "3,5 l Wasser": (3.5, "l", "Wasser", ""),
-            "3.5 l Wasser": (3.5, "l", "Wasser", "")
+            "3.5 l Wasser": (3.5, "l", "Wasser", ""),
+            "400 g Karotte(n)": (400, "g", "Karotte(n)", "")
         }
         # for German you could say that if an ingredient does not have an amount and it starts with a lowercase letter, then that is a unit ("etwas", "evtl.")
         # does not apply to English tho


### PR DESCRIPTION
The new Ingredient Parser failed to parse ingredients like "400 g Karotte(n)", as it will try to match closing brackets with opening brackets only at the start of tokens.

This PR tries to fix that.

Also, the testcases always succeeded, as the wrong function was called and the result was checked for inequality instead of equality.