### PR TITLE
Fix ingredient parsing for fractions using '/'

### DIFF
--- a/cookbook/helper/ingredient_parser.py
+++ b/cookbook/helper/ingredient_parser.py
@@ -28,7 +28,7 @@ def parse_amount(x):
             and (
                     x[end] in string.digits
                     or (
-                            (x[end] == '.' or x[end] == ',')
+                            (x[end] == '.' or x[end] == ',' or x[end] == '/')
                             and end + 1 < len(x)
                             and x[end + 1] in string.digits
                     )
@@ -36,7 +36,10 @@ def parse_amount(x):
     ):
         end += 1
     if end > 0:
-        amount = float(x[:end].replace(',', '.'))
+        if "/" in x[:end]:
+            amount = parse_fraction(x[:end])
+        else:
+            amount = float(x[:end].replace(',', '.'))
     else:
         amount = parse_fraction(x[0])
         end += 1

--- a/cookbook/tests/other/test_edits_recipe.py
+++ b/cookbook/tests/other/test_edits_recipe.py
@@ -33,6 +33,7 @@ class TestEditsRecipe(TestBase):
         expectations = {
             "2¼ l Wasser": (2.25, "l", "Wasser", ""),
             "2¼l Wasser": (2.25, "l", "Wasser", ""),
+            "¼ l Wasser": (0.25, "l", "Wasser", ""),
             "3l Wasser": (3, "l", "Wasser", ""),
             "4 l Wasser": (4, "l", "Wasser", ""),
             "½l Wasser": (0.5, "l", "Wasser", ""),
@@ -43,6 +44,10 @@ class TestEditsRecipe(TestBase):
             "1 Zwiebel(n)": (1, "", "Zwiebel(n)", ""),
             "4 1/2 Zwiebeln": (4.5, "", "Zwiebeln", ""),
             "4 ½ Zwiebeln": (4.5, "", "Zwiebeln", ""),
+            "1/2 EL Mehl": (0.5, "EL", "Mehl", ""),
+            "1/2 Zwiebel": (0.5, "", "Zwiebel", ""),
+            "1/5g Mehl, gesiebt": (0.2, "g", "Mehl", "gesiebt"),
+            "1/2 Zitrone, ausgepresst": (0.5, "", "Zitrone", "ausgepresst"),
             "etwas Mehl": (0, "", "etwas Mehl", ""),
             "Öl zum Anbraten": (0, "", "Öl zum Anbraten", ""),
             "n. B. Knoblauch, zerdrückt": (0, "", "n. B. Knoblauch", "zerdrückt"),


### PR DESCRIPTION
Even though ingredients like '1 1/2 something' already worked fine and got converted to 1.5 something
I just came across a recipe using '1/2' as the whole amount without any whole number before that.
Apparently I overlooked that case before so I now also fixed that.