### PR TITLE
Add DB_OPTIONS to enable DBs with SSL

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -13,6 +13,7 @@ TIMEZONE=Europe/Berlin
 
 # add only a database password if you want to run with the default postgres, otherwise change settings accordingly
 DB_ENGINE=django.db.backends.postgresql
+# DB_OPTIONS= {}
 POSTGRES_HOST=db_recipes
 POSTGRES_PORT=5432
 POSTGRES_USER=djangouser

--- a/recipes/settings.py
+++ b/recipes/settings.py
@@ -175,7 +175,7 @@ WSGI_APPLICATION = 'recipes.wsgi.application'
 DATABASES = {
     'default': {
         'ENGINE': os.getenv('DB_ENGINE') if os.getenv('DB_ENGINE') else 'django.db.backends.sqlite3',
-        'OPTIONS': os.getenv('DB_OPTIONS') if os.getenv('DB_OPTIONS') else [],
+        'OPTIONS': ast.literal_eval(os.getenv('DB_OPTIONS')) if os.getenv('DB_OPTIONS') else {},
         'HOST': os.getenv('POSTGRES_HOST'),
         'PORT': os.getenv('POSTGRES_PORT'),
         'USER': os.getenv('POSTGRES_USER'),

--- a/recipes/settings.py
+++ b/recipes/settings.py
@@ -175,6 +175,7 @@ WSGI_APPLICATION = 'recipes.wsgi.application'
 DATABASES = {
     'default': {
         'ENGINE': os.getenv('DB_ENGINE') if os.getenv('DB_ENGINE') else 'django.db.backends.sqlite3',
+        'OPTIONS': os.getenv('DB_OPTIONS') if os.getenv('DB_OPTIONS') else [],
         'HOST': os.getenv('POSTGRES_HOST'),
         'PORT': os.getenv('POSTGRES_PORT'),
         'USER': os.getenv('POSTGRES_USER'),


### PR DESCRIPTION
Thanks for your work!

When trying to connect to connect to a postgres secured with TLS it failed to connect. With this PR it works:
```
docker run --rm -ti --name recipes -e DB_ENGINE=django.db.backends.postgresql_psycopg2 -e POSTGRES_HOST=recipes-db-postgres-cluster-postgres -e DB_OPTIONS='{"sslmode":"require"}' angelnu/recipes
```