### PR TITLE
Import recipe duplicate keyword fix

### DIFF
--- a/cookbook/helper/recipe_url_import.py
+++ b/cookbook/helper/recipe_url_import.py
@@ -222,6 +222,8 @@ def find_recipe_json(ld_json, url):
         if 'recipeYield' in ld_json:
             if type(ld_json['recipeYield']) == str:
                 ld_json['servings'] = int(re.findall(r'\b\d+\b', ld_json['recipeYield'])[0])
+            elif type(ld_json['recipeYield']) == list:
+                ld_json['servings'] = int(re.findall(r'\b\d+\b', ld_json['recipeYield'][0])[0])
     except Exception as e:
         print(e)
         ld_json['servings'] = 1

--- a/cookbook/tests/api/test_api_keyword.py
+++ b/cookbook/tests/api/test_api_keyword.py
@@ -4,7 +4,6 @@ from cookbook.models import Keyword
 from cookbook.tests.views.test_views import TestViews
 from django.urls import reverse
 
-
 class TestApiKeyword(TestViews):
 
     def setUp(self):
@@ -62,6 +61,26 @@ class TestApiKeyword(TestViews):
         response = json.loads(r.content)
         self.assertEqual(r.status_code, 200)
         self.assertEqual(response['name'], 'new')
+
+    def test_keyword_add(self):
+        r = self.user_client_1.post(
+            reverse('api:keyword-list'),
+            {'name': 'test'},
+            content_type='application/json'
+        )
+        response = json.loads(r.content)
+        self.assertEqual(r.status_code, 201)
+        self.assertEqual(response['name'], 'test')
+
+    def test_keyword_add_duplicate(self):
+        r = self.user_client_1.post(
+            reverse('api:keyword-list'),
+            {'name': self.keyword_1.name},
+            content_type='application/json'
+        )
+        response = json.loads(r.content)
+        self.assertEqual(r.status_code, 201)
+        self.assertEqual(response['name'], {self.keyword_1.name})
 
     def test_keyword_delete(self):
         r = self.user_client_1.delete(

--- a/cookbook/views/data.py
+++ b/cookbook/views/data.py
@@ -134,8 +134,7 @@ def import_url(request):
         recipe.steps.add(step)
 
         for kw in data['keywords']:
-            if kw['id'] != "null" \
-                    and (k := Keyword.objects.filter(id=kw['id']).first()):
+            if k := Keyword.objects.filter(name=kw['text']).first():
                 recipe.keywords.add(k)
             elif data['all_keywords']:
                 k = Keyword.objects.create(name=kw['text'])


### PR DESCRIPTION
when importing a recipe that includes keywords already in use it attempts to create a duplicate name, causing an integrity error.

Also fixed URL import when servings are stored as a list.

I also added a couple of tests on keywords.