### PR TITLE
Cheftap import tweak

### DIFF
--- a/cookbook/integration/cheftap.py
+++ b/cookbook/integration/cheftap.py
@@ -11,7 +11,7 @@ class ChefTap(Integration):
 
     def import_file_name_filter(self, zip_info_object):
         print("testing", zip_info_object.filename)
-        return re.match(r'^recipes/([A-Za-z\d\w\s-])+.txt$', zip_info_object.filename)
+        return re.match(r'^cheftap_export/([A-Za-z\d\w\s-])+.txt$', zip_info_object.filename)
 
     def get_recipe_from_file(self, file):
         source_url = ''

--- a/docs/features/import_export.md
+++ b/docs/features/import_export.md
@@ -121,7 +121,7 @@ thus cannot be imported.
 
 ## ChefTap
 ChefTaps allows you to export your recipes from the app (I think). The export is a zip file containing a folder called
-`recipes` which in turn contains `.txt` files with your recipes.
+`cheftap_export` which in turn contains `.txt` files with your recipes.
 
 This format is basically completely unstructured and every export looks different. This makes importing it very hard
 and leads to suboptimal results. Images are also not supported as they are not included in the export (at least 


### PR DESCRIPTION
When I submitted my testing .zip, I didn't submit my normal export, because that has some personal data in the recipes. Instead, I made one by had, which was a mistake. The folder contained inside is also called cheftap_export. This fixes the code and the docs for ChefTap imports.