### PR TITLE
Fix crash on missing photos in paprika

### DIFF
--- a/cookbook/integration/paprika.py
+++ b/cookbook/integration/paprika.py
@@ -69,5 +69,7 @@ class Paprika(Integration):
 
             recipe.steps.add(step)
 
-            self.import_recipe_image(recipe, BytesIO(base64.b64decode(recipe_json['photo_data'])))
+            if recipe_json.get("photo_data", None):
+                self.import_recipe_image(recipe, BytesIO(base64.b64decode(recipe_json['photo_data'])))
+                
             return recipe


### PR DESCRIPTION
* Fixes a crash on KeyError if `photo_data` does not exist in `recipe_json`.
* Also fixes a crash if `photo_data` is an empty string.
