### PR TITLE
Fix servings input field text direction

### DIFF
--- a/vue/src/apps/RecipeView/RecipeView.vue
+++ b/vue/src/apps/RecipeView/RecipeView.vue
@@ -54,7 +54,7 @@
             </div>
             <div class="my-auto" style="padding-right: 4px">
               <input style="text-align: right; border-width:0px;border:none; padding:0px; padding-left: 0.5vw; padding-right: 8px; max-width: 80px"
-                     value="1" maxlength="3"
+                     value="1" maxlength="3" min="0"
                      type="number" class="form-control form-control-lg" v-model.number="servings"/>
             </div>
             <div class="my-auto">

--- a/vue/src/apps/RecipeView/RecipeView.vue
+++ b/vue/src/apps/RecipeView/RecipeView.vue
@@ -53,8 +53,7 @@
               <i class="fas fa-pizza-slice fa-2x text-primary"></i>
             </div>
             <div class="my-auto" style="padding-right: 4px">
-              <input dir="rtl"
-                     style="border-width:0px;border:none; padding:0px; padding-left: 0.5vw; padding-right: 8px; max-width: 80px"
+              <input style="text-align: right; border-width:0px;border:none; padding:0px; padding-left: 0.5vw; padding-right: 8px; max-width: 80px"
                      value="1" maxlength="3"
                      type="number" class="form-control form-control-lg" v-model.number="servings"/>
             </div>


### PR DESCRIPTION
This fixes #526 and #325

I guess there is no reason to set the text direction to rtl.
To keep the styling I added the text-align: right.

The search didn't show any css that depends on the rtl attribute on purpose, so I guess this should not have styling side affects.