### PR TITLE
Create image_processing.py

### DIFF
--- a/cookbook/helper/image_processing.py
+++ b/cookbook/helper/image_processing.py
@@ -1,0 +1,15 @@
+from PIL import Image
+from io import BytesIO
+
+
+def rescale_image(image_object, base_width=720):
+    img = Image.open(image_object)
+    icc_profile = img.info.get('icc_profile')  # remember color profile to not mess up colors
+    width_percent = (base_width / float(img.size[0]))
+    height = int((float(img.size[1]) * float(width_percent)))
+
+    img = img.resize((base_width, height), Image.ANTIALIAS)
+    img_bytes = BytesIO()
+    img.save(img_bytes, 'JPEG', quality=75, optimize=True, icc_profile=icc_profile)
+
+    return img_bytes


### PR DESCRIPTION
Added central function to rescale and compress images for recipes (or in general).
Switched from previously used PNG format to 75% JPEG format for a 5-10x file size reduction with hardly any quality loss.