### PR TITLE
Update manual setup

### DIFF
--- a/docs/install/manual.md
+++ b/docs/install/manual.md
@@ -60,7 +60,7 @@ Things to edit:
 - `SECRET_KEY`: use something secure.
 - `POSTGRES_HOST`: probably 127.0.0.1.
 - `POSTGRES_PASSWORD`: the password we set earlier when setting up djangodb.
-- `STATIC_URL`, `MEDIA_URL`: these will be in `/var/www/recipes`, under `static/` and `media/` respectively.
+- `STATIC_URL`, `MEDIA_URL`: these will be in `/var/www/recipes`, under `/staticfiles/` and `/mediafiles/` respectively.
 
 ## Initialize the application
 
@@ -103,11 +103,11 @@ WantedBy=multi-user.target
 
 *Note2*: Fix the path in the `ExecStart` line to where you gunicorn and recipes are
 
-Finally, run `sudo systemctl enable gunicorn_recipes.service` and `sudo systemctl start gunicorn_recipes.service`. You can check that the service is correctly started with `systemctl status gunicorn_recipes.service`
+Finally, run `sudo systemctl enable gunicorn_recipes` and `sudo systemctl start gunicorn_recipes`. You can check that the service is correctly started with `systemctl status gunicorn_recipes`
 
 ### nginx
 
-Now we tell nginx to listen to a new port and forward that to gunicorn. `sudo nano /etc/nginx/sites-available/recipes.conf`
+Now we tell nginx to listen to a new port and forward that to gunicorn. `sudo nano /etc/nginx/conf.d/recipes.conf`
 
 And enter these lines:
 
@@ -118,11 +118,11 @@ server {
     #error_log /var/log/nginx/error.log;
 
     # serve media files
-    location /static {
+    location /staticfiles {
         alias /var/www/recipes/staticfiles;
     }
     
-    location /media {
+    location /mediafiles {
         alias /var/www/recipes/mediafiles;
     }
 
@@ -135,4 +135,4 @@ server {
 
 *Note*: Enter the correct path in static and proxy_pass lines.
 
-Enable the website `sudo ln -s /etc/nginx/sites-available/recipes.conf /etc/nginx/sites-enabled` and restart nginx : `sudo systemctl restart nginx.service`
+Reload nginx : `sudo systemctl reload nginx`

--- a/docs/install/manual.md
+++ b/docs/install/manual.md
@@ -119,6 +119,7 @@ server {
     }
 
     location / {
+        proxy_set_header Host $http_host;
         proxy_pass http://unix:/var/www/recipes/recipes.sock;
     }
 }

--- a/docs/install/manual.md
+++ b/docs/install/manual.md
@@ -13,6 +13,8 @@ Get the last version from the repository: `git clone https://github.com/vabene11
 
 Move it to the `/var/www` directory: `mv recipes /var/www`
 
+Change to the directory: `cd /var/www/recipes`
+
 Give the user permissions: `chown -R recipes:www-data /var/www/recipes`
 
 Create virtual env: `python3.9 -m venv /var/www/recipes`
@@ -53,6 +55,12 @@ Download the `.env` configuration file and **edit it accordingly**.
 ```shell
 wget https://raw.githubusercontent.com/vabene1111/recipes/develop/.env.template -O /var/www/recipes/.env
 ```
+
+Things to edit:
+- `SECRET_KEY`: use something secure.
+- `POSTGRES_HOST`: probably 127.0.0.1.
+- `POSTGRES_PASSWORD`: the password we set earlier when setting up djangodb.
+- `STATIC_URL`, `MEDIA_URL`: these will be in `/var/www/recipes`, under `static/` and `media/` respectively.
 
 ## Initialize the application
 


### PR DESCRIPTION
I just went through a manual install on DietPi / Debian Unstable, and found that the manual needed some improving, this method works, whereas following the original manual was not a success for me.

The only line I would say I am unsure about is this one:
"Give the user permissions: `chown -R recipes:www-data /var/www/recipes`"
As I am not sure whether these permissions are necessary for this to work.

Hope this is useful, let me know if I can make further improvements.