### PR TITLE
Send proper protocol to Django from Nginx

### DIFF
--- a/docs/install/manual.md
+++ b/docs/install/manual.md
@@ -129,6 +129,7 @@ server {
     location / {
         proxy_set_header Host $http_host;
         proxy_pass http://unix:/var/www/recipes/recipes.sock;
+        proxy_set_header X-Forwarded-Proto $scheme;
     }
 }
 ```


### PR DESCRIPTION
In order to run over HTTPS* django requires the X-Forwarded-Proto header sent from the nginx proxy. I didn't add everything needed for TLS, but this header works with HTTP and HTTPS so I figure it might save a few people some time if they ever decide to secure their installation.

\* specifically, I noticed that image URLs are requested over HTTP instead of HTTPS even when the main page is HTTPS until this header is sent