### PR TITLE
Allow specifying port through TANDOOR_PORT environment variable

### DIFF
--- a/boot.sh
+++ b/boot.sh
@@ -1,6 +1,8 @@
 #!/bin/sh
 source venv/bin/activate
 
+TANDOOR_PORT="${TANDOOR_PORT:-8080}"
+
 echo "Updating database"
 python manage.py migrate
 python manage.py collectstatic_js_reverse
@@ -9,4 +11,4 @@ echo "Done"
 
 chmod -R 755 /opt/recipes/mediafiles
 
-exec gunicorn -b :8080 --access-logfile - --error-logfile - --log-level INFO recipes.wsgi
+exec gunicorn -b :$TANDOOR_PORT --access-logfile - --error-logfile - --log-level INFO recipes.wsgi


### PR DESCRIPTION
While Docker containers have their own IP address namespace and port collisions are impossible to achieve, other container solutions share one.
Podman, for example, runs all containers in a pod under one namespace, which results in every port only being allowed to be assigned once. Having a default port in the image that cannot be changed can cause collisions and incompabilities.

This change allows setting a custom port for Gunicorn through the environment while keeping the default port as fallback to keep backwards compatibility.