### PR TITLE
Sort tree enhancements

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -128,4 +128,5 @@ REVERSE_PROXY_AUTH=0
 # however, when doing large imports of recipes that will create new objects, can increase total run time by 5-10x
 # Disabling SORT_TREE_BY_NAME (setting value to 0) will store objects unsorted, but will substantially increase speed of imports.
 # Keywords and Food can be manually sorted by name in Admin
+# This value can also be temporarily changed in Admin, it will revert the next time the application is started
 # SORT_TREE_BY_NAME=0

--- a/.env.template
+++ b/.env.template
@@ -121,3 +121,11 @@ REVERSE_PROXY_AUTH=0
 # when running under the same database
 # SESSION_COOKIE_DOMAIN=.example.com
 # SESSION_COOKIE_NAME=sessionid # use this only to not interfere with non unified django applications under the same top level domain
+
+
+# by default SORT_TREE_BY_NAME is enabled this will store all Keywords and Food in case sensitive order
+# this setting makes saving new keywords and foods very slow, which doesn't matter in most usecases.
+# however, when doing large imports of recipes that will create new objects, can increase total run time by 5-10x
+# Disabling SORT_TREE_BY_NAME (setting value to 0) will store objects unsorted, but will substantially increase speed of imports.
+# Keywords and Food can be manually sorted by name in Admin
+# SORT_TREE_BY_NAME=0

--- a/cookbook/admin.py
+++ b/cookbook/admin.py
@@ -89,7 +89,7 @@ class SyncLogAdmin(admin.ModelAdmin):
 admin.site.register(SyncLog, SyncLogAdmin)
 
 
-@admin.action(description='Sort tree by name')
+@admin.action(description='Fix problems and sort tree by name')
 def sort_tree(modeladmin, request, queryset):
     modeladmin.model.node_order_by = ['name']
     with scopes_disabled():

--- a/cookbook/admin.py
+++ b/cookbook/admin.py
@@ -89,19 +89,34 @@ class SyncLogAdmin(admin.ModelAdmin):
 admin.site.register(SyncLog, SyncLogAdmin)
 
 
+@admin.action(description='Temporarily ENABLE sorting on Foods and Keywords.')
+def enable_tree_sorting(modeladmin, request, queryset):
+    Food.node_order_by = ['name']
+    Keyword.node_order_by = ['name']
+    with scopes_disabled():
+        Food.fix_tree(fix_paths=True)
+        Keyword.fix_tree(fix_paths=True)
+
+
+@admin.action(description='Temporarily DISABLE sorting on Foods and Keywords.')
+def disable_tree_sorting(modeladmin, request, queryset):
+    Food.node_order_by = []
+    Keyword.node_order_by = []
+
+
 @admin.action(description='Fix problems and sort tree by name')
 def sort_tree(modeladmin, request, queryset):
     orginal_value = modeladmin.model.node_order_by[:]
     modeladmin.model.node_order_by = ['name']
     with scopes_disabled():
-        Keyword.fix_tree(fix_paths=True)
+        modeladmin.model.fix_tree(fix_paths=True)
     modeladmin.model.node_order_by = orginal_value
 
 
 class KeywordAdmin(TreeAdmin):
     form = movenodeform_factory(Keyword)
     ordering = ('space', 'path',)
-    actions = [sort_tree]
+    actions = [sort_tree, enable_tree_sorting, disable_tree_sorting]
 
 
 admin.site.register(Keyword, KeywordAdmin)
@@ -148,7 +163,7 @@ admin.site.register(Unit)
 class FoodAdmin(TreeAdmin):
     form = movenodeform_factory(Keyword)
     ordering = ('space', 'path',)
-    actions = [sort_tree]
+    actions = [sort_tree, enable_tree_sorting, disable_tree_sorting]
 
 
 admin.site.register(Food, FoodAdmin)

--- a/cookbook/admin.py
+++ b/cookbook/admin.py
@@ -91,10 +91,11 @@ admin.site.register(SyncLog, SyncLogAdmin)
 
 @admin.action(description='Fix problems and sort tree by name')
 def sort_tree(modeladmin, request, queryset):
+    orginal_value = modeladmin.model.node_order_by[:]
     modeladmin.model.node_order_by = ['name']
     with scopes_disabled():
         Keyword.fix_tree(fix_paths=True)
-    modeladmin.model.node_order_by = []
+    modeladmin.model.node_order_by = orginal_value
 
 
 class KeywordAdmin(TreeAdmin):

--- a/cookbook/admin.py
+++ b/cookbook/admin.py
@@ -89,9 +89,18 @@ class SyncLogAdmin(admin.ModelAdmin):
 admin.site.register(SyncLog, SyncLogAdmin)
 
 
+@admin.action(description='Sort tree by name')
+def sort_tree(modeladmin, request, queryset):
+    modeladmin.model.node_order_by = ['name']
+    with scopes_disabled():
+        Keyword.fix_tree(fix_paths=True)
+    modeladmin.model.node_order_by = []
+
+
 class KeywordAdmin(TreeAdmin):
     form = movenodeform_factory(Keyword)
     ordering = ('space', 'path',)
+    actions = [sort_tree]
 
 
 admin.site.register(Keyword, KeywordAdmin)
@@ -138,6 +147,7 @@ admin.site.register(Unit)
 class FoodAdmin(TreeAdmin):
     form = movenodeform_factory(Keyword)
     ordering = ('space', 'path',)
+    actions = [sort_tree]
 
 
 admin.site.register(Food, FoodAdmin)

--- a/cookbook/models.py
+++ b/cookbook/models.py
@@ -19,7 +19,7 @@ from treebeard.mp_tree import MP_Node, MP_NodeManager
 from django_scopes import ScopedManager, scopes_disabled
 from django_prometheus.models import ExportModelOperationsMixin
 from recipes.settings import (COMMENT_PREF_DEFAULT, FRACTION_PREF_DEFAULT,
-                              STICKY_NAV_PREF_DEFAULT)
+                              STICKY_NAV_PREF_DEFAULT, SORT_TREE_BY_NAME)
 
 
 def get_user_name(self):
@@ -335,8 +335,8 @@ class SyncLog(models.Model, PermissionModelMixin):
 
 
 class Keyword(ExportModelOperationsMixin('keyword'), TreeModel, PermissionModelMixin):
-    # TODO add find and fix problem functions
-    # node_order_by = ['name']
+    if SORT_TREE_BY_NAME:
+        node_order_by = ['name']
     name = models.CharField(max_length=64)
     icon = models.CharField(max_length=16, blank=True, null=True)
     description = models.TextField(default="", blank=True)
@@ -370,8 +370,8 @@ class Unit(ExportModelOperationsMixin('unit'), models.Model, PermissionModelMixi
 
 
 class Food(ExportModelOperationsMixin('food'), TreeModel, PermissionModelMixin):
-    # TODO add find and fix problem functions
-    # node_order_by = ['name']
+    if SORT_TREE_BY_NAME:
+        node_order_by = ['name']
     name = models.CharField(max_length=128, validators=[MinLengthValidator(1)])
     recipe = models.ForeignKey('Recipe', null=True, blank=True, on_delete=models.SET_NULL)
     supermarket_category = models.ForeignKey(SupermarketCategory, null=True, blank=True, on_delete=models.SET_NULL)

--- a/cookbook/models.py
+++ b/cookbook/models.py
@@ -43,8 +43,7 @@ class TreeManager(MP_NodeManager):
         try:
             return self.get(name__exact=kwargs['name'], space=kwargs['space']), False
         except self.model.DoesNotExist:
-            with scopes_disabled():
-                return self.model.add_root(**kwargs), True
+            return self.model.add_root(**kwargs), True
 
 
 class TreeModel(MP_Node):
@@ -353,6 +352,13 @@ class Keyword(ExportModelOperationsMixin('keyword'), TreeModel, PermissionModelM
         indexes = (Index(fields=['id', 'name']),)
 
 
+# when starting up run fix_tree to:
+#   a) make sure that nodes are sorted when switching between sort modes
+#   b) fix problems, if any, with tree consistency
+with scopes_disabled():
+    Keyword.fix_tree(fix_paths=True)
+
+
 class Unit(ExportModelOperationsMixin('unit'), models.Model, PermissionModelMixin):
     name = models.CharField(max_length=128, validators=[MinLengthValidator(1)])
     description = models.TextField(blank=True, null=True)
@@ -398,6 +404,13 @@ class Food(ExportModelOperationsMixin('food'), TreeModel, PermissionModelMixin):
             Index(fields=['id']),
             Index(fields=['name']),
         )
+
+
+# when starting up run fix_tree to:
+#   a) make sure that nodes are sorted when switching between sort modes
+#   b) fix problems, if any, with tree consistency
+with scopes_disabled():
+    Food.fix_tree(fix_paths=True)
 
 
 class Ingredient(ExportModelOperationsMixin('ingredient'), models.Model, PermissionModelMixin):
@@ -793,7 +806,7 @@ class ViewLog(ExportModelOperationsMixin('view_log'), models.Model, PermissionMo
     class Meta():
         indexes = (
             Index(fields=['recipe']),
-            Index(fields=[ '-created_at']),
+            Index(fields=['-created_at']),
             Index(fields=['created_by']),
             Index(fields=['recipe', '-created_at', 'created_by']),
         )

--- a/cookbook/tests/api/test_api_food.py
+++ b/cookbook/tests/api/test_api_food.py
@@ -21,6 +21,10 @@ LIST_URL = 'api:food-list'
 DETAIL_URL = 'api:food-detail'
 MOVE_URL = 'api:food-move'
 MERGE_URL = 'api:food-merge'
+if (Food.node_order_by):
+    node_location = 'sorted-child'
+else:
+    node_location = 'last-child'
 
 
 @pytest.fixture()
@@ -264,7 +268,7 @@ def test_integrity(u1_s1, recipe_1_s1):
         i_1.step_set.first().ingredients.remove(i_1)
         assert Food.objects.count() == 10
         assert Ingredient.objects.count() == 10
-    
+
     # deleting food will succeed because its not part of recipe and delete will cascade to Ingredient
     r = u1_s1.delete(
         reverse(
@@ -429,7 +433,7 @@ def test_root_filter(obj_1, obj_1_1, obj_1_1_1, obj_2, obj_3, u1_s1):
     assert len(response['results']) == 2
 
     with scopes_disabled():
-        obj_2.move(obj_1, 'last-child')
+        obj_2.move(obj_1, node_location)
     # should return direct children of obj_1 (obj_1_1, obj_2), ignoring query filters
     response = json.loads(u1_s1.get(f'{reverse(LIST_URL)}?root={obj_1.id}').content)
     assert response['count'] == 2
@@ -439,7 +443,7 @@ def test_root_filter(obj_1, obj_1_1, obj_1_1_1, obj_2, obj_3, u1_s1):
 
 def test_tree_filter(obj_1, obj_1_1, obj_1_1_1, obj_2, obj_3, u1_s1):
     with scopes_disabled():
-        obj_2.move(obj_1, 'last-child')
+        obj_2.move(obj_1, node_location)
     # should return full tree starting at obj_1 (obj_1_1_1, obj_2), ignoring query filters
     response = json.loads(u1_s1.get(f'{reverse(LIST_URL)}?tree={obj_1.id}').content)
     assert response['count'] == 4

--- a/cookbook/tests/api/test_api_keyword.py
+++ b/cookbook/tests/api/test_api_keyword.py
@@ -20,7 +20,10 @@ LIST_URL = 'api:keyword-list'
 DETAIL_URL = 'api:keyword-detail'
 MOVE_URL = 'api:keyword-move'
 MERGE_URL = 'api:keyword-merge'
-
+if (Keyword.node_order_by):
+    node_location = 'sorted-child'
+else:
+    node_location = 'last-child'
 
 @pytest.fixture()
 def obj_1(space_1):
@@ -350,7 +353,7 @@ def test_root_filter(obj_1, obj_1_1, obj_1_1_1, obj_2, obj_3, u1_s1):
     assert len(response['results']) == 2
 
     with scopes_disabled():
-        obj_2.move(obj_1, 'last-child')
+        obj_2.move(obj_1, node_location)
     # should return direct children of obj_1 (obj_1_1, obj_2), ignoring query filters
     response = json.loads(u1_s1.get(f'{reverse(LIST_URL)}?root={obj_1.id}').content)
     assert response['count'] == 2
@@ -360,7 +363,7 @@ def test_root_filter(obj_1, obj_1_1, obj_1_1_1, obj_2, obj_3, u1_s1):
 
 def test_tree_filter(obj_1, obj_1_1, obj_1_1_1, obj_2, obj_3, u1_s1):
     with scopes_disabled():
-        obj_2.move(obj_1, 'last-child')
+        obj_2.move(obj_1, node_location)
     # should return full tree starting at obj_1 (obj_1_1_1, obj_2), ignoring query filters
     response = json.loads(u1_s1.get(f'{reverse(LIST_URL)}?tree={obj_1.id}').content)
     assert response['count'] == 4

--- a/recipes/settings.py
+++ b/recipes/settings.py
@@ -73,7 +73,8 @@ ACCOUNT_SIGNUP_FORM_CLASS = 'cookbook.forms.AllAuthSignupForm'
 TERMS_URL = os.getenv('TERMS_URL', '')
 PRIVACY_URL = os.getenv('PRIVACY_URL', '')
 IMPRINT_URL = os.getenv('IMPRINT_URL', '')
-SORT_TREE_BY_NAME = os.getenv('IMPRINT_URL', 1)
+if SORT_TREE_BY_NAME:= bool(int(os.getenv('SQL_DEBUG', True))):
+    MIDDLEWARE += ('recipes.middleware.SqlPrintingMiddleware',)
 
 HOSTED = bool(int(os.getenv('HOSTED', False)))
 
@@ -391,5 +392,3 @@ EMAIL_USE_SSL = bool(int(os.getenv('EMAIL_USE_SSL', False)))
 DEFAULT_FROM_EMAIL = os.getenv('DEFAULT_FROM_EMAIL', 'webmaster@localhost')
 ACCOUNT_EMAIL_SUBJECT_PREFIX = os.getenv('ACCOUNT_EMAIL_SUBJECT_PREFIX', '[Tandoor Recipes] ')  # allauth sender prefix
 
-if os.getenv('SQL_DEBUG', False):
-    MIDDLEWARE += ('recipes.middleware.SqlPrintingMiddleware',)

--- a/recipes/settings.py
+++ b/recipes/settings.py
@@ -73,6 +73,7 @@ ACCOUNT_SIGNUP_FORM_CLASS = 'cookbook.forms.AllAuthSignupForm'
 TERMS_URL = os.getenv('TERMS_URL', '')
 PRIVACY_URL = os.getenv('PRIVACY_URL', '')
 IMPRINT_URL = os.getenv('IMPRINT_URL', '')
+SORT_TREE_BY_NAME = os.getenv('IMPRINT_URL', 1)
 
 HOSTED = bool(int(os.getenv('HOSTED', False)))
 

--- a/recipes/wsgi.py
+++ b/recipes/wsgi.py
@@ -10,8 +10,17 @@ https://docs.djangoproject.com/en/2.0/howto/deployment/wsgi/
 import os
 
 from django.core.wsgi import get_wsgi_application
+from django_scopes import scopes_disabled
+from cookbook.models import Food, Keyword
 
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "recipes.settings")
+
+# run fix tree here solves 2 problems:
+# 1 if tree sorting is changed from unsorted to sorted ensures that objects are sorted
+# 2 if any condition caused the tree to be in an inconsistent state this will fix most problems
+with scopes_disabled():
+    Food.fix_tree(fix_paths=True)
+    Keyword.fix_tree(fix_paths=True)
 
 _application = get_wsgi_application()
 

--- a/recipes/wsgi.py
+++ b/recipes/wsgi.py
@@ -8,19 +8,9 @@ https://docs.djangoproject.com/en/2.0/howto/deployment/wsgi/
 """
 
 import os
-
 from django.core.wsgi import get_wsgi_application
-from django_scopes import scopes_disabled
-from cookbook.models import Food, Keyword
 
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "recipes.settings")
-
-# run fix tree here solves 2 problems:
-# 1 if tree sorting is changed from unsorted to sorted ensures that objects are sorted
-# 2 if any condition caused the tree to be in an inconsistent state this will fix most problems
-with scopes_disabled():
-    Food.fix_tree(fix_paths=True)
-    Keyword.fix_tree(fix_paths=True)
 
 _application = get_wsgi_application()
 


### PR DESCRIPTION
Allows disabling sort_tree in ENV variable (enabled by default)
Admin function to manually sort tree
Admin function to Enable/Disable tree sorting (will revert to ENV value on app restart)

At app startup run fix_tree - will resolve any problems found (includes sorting nodes if switching between sorted/unsorted)

> nodes with characters not found in the alphabet
> nodes when a wrong path length according to steplen
> orphaned nodes
> nodes with the wrong depth value for their path
> wrong number of children