### PR TITLE
Also show working/waiting time if only one of both is set

### DIFF
--- a/vue/src/components/RecipeCard.vue
+++ b/vue/src/components/RecipeCard.vue
@@ -12,11 +12,11 @@
         </a>
       </div>
       <div class="card-img-overlay w-50 d-flex flex-column justify-content-left float-left text-left pt-2"
-           v-if="recipe.waiting_time !== 0">
-        <b-badge pill variant="light" class="mt-1 font-weight-normal"><i class="fa fa-clock"></i>
+           v-if="recipe.working_time !== 0 && recipe.waiting_time !== 0">
+        <b-badge pill variant="light" class="mt-1 font-weight-normal" v-if="recipe.working_time !== 0"><i class="fa fa-clock"></i>
           {{ recipe.working_time }} {{ $t('min') }}
         </b-badge>
-        <b-badge pill variant="secondary" class="mt-1 font-weight-normal"><i class="fa fa-pause"></i>
+        <b-badge pill variant="secondary" class="mt-1 font-weight-normal" v-if="recipe.waiting_time !== 0"><i class="fa fa-pause"></i>
           {{ recipe.waiting_time }} {{ $t('min') }}
         </b-badge>
       </div>


### PR DESCRIPTION
Currently, the working/waiting time is only shown on cards if there is a waiting time. This pull request shows the working time, even if no waiting time is set.